### PR TITLE
Add table of content inside navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"axios": "0.27.2",
 		"blurhash": "1.1.5",
 		"image-hash": "^5.3.1",
+		"jsdom": "^22.1.0",
 		"potrace": "^2.1.8",
 		"rehype-autolink-headings": "^6.1.1",
 		"rehype-slug": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   image-hash:
     specifier: ^5.3.1
     version: 5.3.1
+  jsdom:
+    specifier: ^22.1.0
+    version: 22.1.0
   potrace:
     specifier: ^2.1.8
     version: 2.1.8
@@ -708,6 +711,11 @@ packages:
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
     dev: false
 
+  /@tootallnate/once@2.0.0:
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+    dev: false
+
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
@@ -886,6 +894,10 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
+  /abab@2.0.6:
+    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    dev: false
+
   /acorn-jsx@5.3.2(acorn@8.8.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -899,6 +911,15 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
+
+  /agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /aggregate-error@4.0.1:
     resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
@@ -1338,11 +1359,27 @@ packages:
     dependencies:
       css-tree: 1.1.3
 
+  /cssstyle@3.0.0:
+    resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
+    engines: {node: '>=14'}
+    dependencies:
+      rrweb-cssom: 0.6.0
+    dev: false
+
   /dashdash@1.14.1:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
     dependencies:
       assert-plus: 1.0.0
+    dev: false
+
+  /data-urls@4.0.0:
+    resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
+    engines: {node: '>=14'}
+    dependencies:
+      abab: 2.0.6
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 12.0.1
     dev: false
 
   /debug@4.3.4:
@@ -1355,7 +1392,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -1374,6 +1410,10 @@ packages:
     resolution: {integrity: sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==}
     engines: {node: '>=10'}
     dev: true
+
+  /decimal.js@10.4.3:
+    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
+    dev: false
 
   /decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1462,6 +1502,13 @@ packages:
   /domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
 
+  /domexception@4.0.0:
+    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
+    engines: {node: '>=12'}
+    dependencies:
+      webidl-conversions: 7.0.0
+    dev: false
+
   /domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
@@ -1494,6 +1541,11 @@ packages:
 
   /entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+    dev: false
 
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -2181,6 +2233,24 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
+  /html-encoding-sniffer@3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
+    dependencies:
+      whatwg-encoding: 2.0.0
+    dev: false
+
+  /http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /http-signature@1.2.0:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
     engines: {node: '>=0.8', npm: '>=1.3.7'}
@@ -2188,6 +2258,23 @@ packages:
       assert-plus: 1.0.0
       jsprim: 1.4.2
       sshpk: 1.17.0
+    dev: false
+
+  /https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
     dev: false
 
   /ieee754@1.2.1:
@@ -2323,6 +2410,10 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+    dev: false
+
   /is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
     dev: false
@@ -2366,6 +2457,44 @@ packages:
 
   /jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+    dev: false
+
+  /jsdom@22.1.0:
+    resolution: {integrity: sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      abab: 2.0.6
+      cssstyle: 3.0.0
+      data-urls: 4.0.0
+      decimal.js: 10.4.3
+      domexception: 4.0.0
+      form-data: 4.0.0
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.5
+      parse5: 7.1.2
+      rrweb-cssom: 0.6.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.2
+      w3c-xmlserializer: 4.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 12.0.1
+      ws: 8.13.0
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
     dev: false
 
   /json-parse-even-better-errors@2.3.1:
@@ -2600,7 +2729,6 @@ packages:
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
 
   /nanoid@3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
@@ -2664,6 +2792,10 @@ packages:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
       boolbase: 1.0.0
+
+  /nwsapi@2.2.5:
+    resolution: {integrity: sha512-6xpotnECFy/og7tKSBVmUNft7J3jyXAka4XvG6AUhFWRz+Q/Ljus7znJAA3bxColfQLdS+XsjoodtJfCgeTEFQ==}
+    dev: false
 
   /oauth-sign@0.9.0:
     resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
@@ -2750,6 +2882,12 @@ packages:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
     dev: true
+
+  /parse5@7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+    dependencies:
+      entities: 4.5.0
+    dev: false
 
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3213,6 +3351,10 @@ packages:
     engines: {node: '>=0.6'}
     dev: false
 
+  /querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+    dev: false
+
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
@@ -3337,6 +3479,10 @@ packages:
       uuid: 3.4.0
     dev: false
 
+  /requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+    dev: false
+
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3377,6 +3523,10 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
+
+  /rrweb-cssom@0.6.0:
+    resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
+    dev: false
 
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3420,6 +3570,13 @@ packages:
 
   /sax@1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
+    dev: false
+
+  /saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+    dependencies:
+      xmlchars: 2.2.0
     dev: false
 
   /semver@7.3.8:
@@ -3758,6 +3915,10 @@ packages:
       picocolors: 1.0.0
       stable: 0.1.8
 
+  /symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+    dev: false
+
   /tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
     dependencies:
@@ -3817,6 +3978,23 @@ packages:
     engines: {node: '>=0.8'}
     dependencies:
       psl: 1.9.0
+      punycode: 2.3.0
+    dev: false
+
+  /tough-cookie@4.1.2:
+    resolution: {integrity: sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      psl: 1.9.0
+      punycode: 2.3.0
+      universalify: 0.2.0
+      url-parse: 1.5.10
+    dev: false
+
+  /tr46@4.1.1:
+    resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
+    engines: {node: '>=14'}
+    dependencies:
       punycode: 2.3.0
     dev: false
 
@@ -3925,6 +4103,11 @@ packages:
       unist-util-visit-parents: 5.1.3
     dev: false
 
+  /universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+    dev: false
+
   /update-browserslist-db@1.0.10(browserslist@4.21.5):
     resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
     hasBin: true
@@ -3940,6 +4123,13 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.0
+
+  /url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
+    dev: false
 
   /utif@2.0.1:
     resolution: {integrity: sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==}
@@ -4040,6 +4230,38 @@ packages:
       vite: 3.2.5(sass@1.59.3)
     dev: true
 
+  /w3c-xmlserializer@4.0.0:
+    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
+    engines: {node: '>=14'}
+    dependencies:
+      xml-name-validator: 4.0.0
+    dev: false
+
+  /webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /whatwg-encoding@2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: false
+
+  /whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /whatwg-url@12.0.1:
+    resolution: {integrity: sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      tr46: 4.1.1
+      webidl-conversions: 7.0.0
+    dev: false
+
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -4056,6 +4278,19 @@ packages:
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  /ws@8.13.0:
+    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
   /xhr@2.6.0:
     resolution: {integrity: sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==}
     dependencies:
@@ -4063,6 +4298,11 @@ packages:
       is-function: 1.0.2
       parse-headers: 2.0.5
       xtend: 4.0.2
+    dev: false
+
+  /xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
     dev: false
 
   /xml-parse-from-string@1.0.1:
@@ -4080,6 +4320,10 @@ packages:
   /xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+    dev: false
+
+  /xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: false
 
   /xtend@4.0.2:

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -17,6 +17,7 @@ declare namespace App {
 			date: string,
 		},
 		path: string,
+		toc: string | null
 	}
 
 	// interface Platform {}

--- a/src/components/collapsible.svelte
+++ b/src/components/collapsible.svelte
@@ -12,7 +12,7 @@
 
   $: collapsed_icon  = collapsed ? faPlus : faMinus;
   $: collapsed_class = collapsed ? "" : " active";
-  $: collapsed_style = collapsed ? "" : `max-height: none`;
+  $: collapsed_style = collapsed ? "" : `max-height: none; --nav-background-color: rgba(0,0,0,0.1)`;
 </script>
 
 <div>
@@ -21,7 +21,7 @@
       {name.toUpperCase()} <span class="icon-right"><Fa icon={collapsed_icon} /></span>
     </button>
   </div>
-  <div class="content" style={collapsed_style} bind:this={content_el}>
+  <div class="content" style={collapsed_style} class:expanded={!collapsed} bind:this={content_el}>
     {#each posts as post}
       <NavItem {post} />
     {/each}
@@ -32,4 +32,8 @@
 	.collapsible .icon-right {
 		float: right;
 	}
+
+  .expanded {
+    background-color: rgba(0,0,0,0.1);
+  }
 </style>

--- a/src/components/collapsible.svelte
+++ b/src/components/collapsible.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Fa from "svelte-fa";
 	import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
+	import NavItem from "./navItem.svelte";
 
   export let name: string;
   export let posts: App.Post[];
@@ -12,26 +13,6 @@
   $: collapsed_icon  = collapsed ? faPlus : faMinus;
   $: collapsed_class = collapsed ? "" : " active";
   $: collapsed_style = collapsed ? "" : `max-height: none`;
-
-  let isNew = (date: string) => {
-    if(date === undefined) return false;
-
-    let delayedDate = new Date();
-    delayedDate.setMonth(delayedDate.getMonth() - 1);
-
-    let postDate = new Date();
-    let args = date.split('/').map(el => Number.parseInt(el, 10));
-    postDate.setDate(args[0]);
-    postDate.setMonth(args[1] - 1);
-    postDate.setFullYear(args[2]);
-
-    if (isNaN(postDate.getTime())) return false;
-
-    /**
-     * If the post date is greater than today's date - 1 month, show the span
-     */
-    return postDate.getTime() > delayedDate.getTime()
-  }
 </script>
 
 <div>
@@ -42,12 +23,7 @@
   </div>
   <div class="content" style={collapsed_style} bind:this={content_el}>
     {#each posts as post}
-      <a class="nav-link" href={ post.path }>
-        {post.meta.title}
-        {#if isNew(post.meta.date) }<span class="new-badge keepTag" style="margin-right: 5px;">NEW</span>{/if}
-        {#if 'deprecated' in post.meta && post.meta.deprecated}<span class="deprecated-badge">DEPRECATED</span>{/if}
-        {#if 'archived' in post.meta && post.meta.archived}<span class="archived-badge">ARCHIVED</span>{/if}
-      </a>
+      <NavItem {post} />
     {/each}
   </div>
 </div>

--- a/src/components/footer.svelte
+++ b/src/components/footer.svelte
@@ -1,11 +1,26 @@
 <script lang="ts">
 	import ThemeButton from "./themeButton.svelte";
 
+	export let absolute: boolean = false;
+
 	$: year = new Date().getFullYear().toString();
 </script>
 
-<footer>
+<footer class:absolute>
 	<p>&copy; { year } Faithful Resource Pack</p>
-	<p><ThemeButton inline /></p>
+	<p style="font-size: 0.7em; line-height: 1.1">
+		Made with <a href="https://svelte.dev/" target="_blank" rel="noopener noreferrer">Svelte</a>
+		<br>
+		<ThemeButton inline />
+	</p>
 	<p><small>"Minecraft" is a trademark of Microsoft Corporation and not affiliated with this site. Visit the <a href="https://www.minecraft.net/">official site</a> to get the game!</small></p>
 </footer>
+
+<style lang="scss">
+	footer.absolute {
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+	}
+</style>

--- a/src/components/header.svelte
+++ b/src/components/header.svelte
@@ -33,10 +33,12 @@
 
 	// after content rendered to the DOM
 	onMount(async () => {
-  	const Hammer = await import("svelte-hammer")
+		// swipe event import
+  		const Hammer = await import("svelte-hammer")
 
 		// ensure client-side code
 		if(browser) {
+			handleScroll(); // make sure at startup
 			document.addEventListener('scroll', handleScroll);
 
 			// nav-swipe is not null
@@ -47,7 +49,7 @@
 	})
 </script>
 
-<header class={$nav_class + ' ' + shadow_class}>
+<header class={$nav_class + ' ' + shadow_class} class:border={shadow}>
 	<button id="menuBtn" class="header-button" type="button" on:click={ menu_opened.toggle }>Menu</button>
 	<h1 class="small-display maintitle">
 		<span class="height" /><a href="/">
@@ -62,21 +64,87 @@
 	<div id="nav-swipe"></div>
 	<div id="nav-bg" class={$nav_class} on:click={() => $menu_opened = false} on:keydown={() => {}}></div>
 	<nav class={$nav_class}>
-		<div id="nav-img">Logo</div>
-		<ThemeButton navLink />
+		<div id="nav-img" class:border={shadow}>
+			<a href="/">
+				<img height="48" width="48" src="https://raw.githubusercontent.com/Faithful-Resource-Pack/Branding/main/logos/transparent/64/plain_logo.png" alt="F">
+				<Fa id="icon" icon={faHome} size="xs" />
+			</a>
+			<ThemeButton inline={true} />
+		</div>
 
-		{#if new URL($page.url).pathname !== '/'}
-			<a class="nav-link home" style="height: 36px; line-height: 36px;" href="/">HOME <span class="icon-right"><Fa icon={faHome} /></span></a>
-		{/if}
-
-		{#each categories as item}
-			<Collapsible name={item} posts={posts.filter(p => p.meta.type === item)} />
-		{/each}
+		<div id="nav-list">
+			{#each categories as item}
+				<Collapsible name={item} posts={posts.filter(p => p.meta.type === item)} />
+			{/each}
+		</div>
 	</nav>
 </header>
 
 <style lang="scss">
 	.nav-link .icon-right {
 		float: right;
+	}
+
+	$border-color: var(--header-border-color, rgba(0,0,0,0.5));
+	// Header little border
+	header {
+		@include little-border(transparent);
+
+		&.border {
+			@include little-border-color($border-color);
+		}
+	}
+
+	#nav-img {
+		position: relative;
+		@include little-border(transparent);
+
+		&.border {
+			@include little-border-color($border-color);
+		}
+	}
+
+	#nav-img {
+		a {
+			margin: 4px 0;
+			padding-right: 10px;
+			color: inherit;
+
+			& :global( > *) {
+				display: inline-block;
+				vertical-align: middle;
+				transition: opacity 0.2s ease;
+			}
+
+			// opacity effect
+			& :global( > div) {
+				opacity: 0.8;
+			}
+			& :global( > div + svg) {
+				margin-left: 3px;
+				opacity: 0.7;
+			}
+			&:hover :global( > *) {
+				opacity: 1;
+			}
+		}
+	}
+
+	nav {
+		display: flex;
+		flex-direction: column;
+		color: var(--nav-text-color, inherit);
+
+		#nav-list {
+			flex-grow: 1;
+			overflow-y: auto;
+			padding-top: 3px;
+		}
+
+		& :global {
+			ol, ul, li {
+				color: var(--nav-text-color, inherit);
+			}
+		}
 	}
 </style>

--- a/src/components/navItem.svelte
+++ b/src/components/navItem.svelte
@@ -2,7 +2,6 @@
 	import Fa from "svelte-fa";
 	import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 	import { page } from "$app/stores";
-	import { onMount } from "svelte";
 
 	export let post: App.Post;
 
@@ -28,7 +27,8 @@
 
   $: hasToc = post.toc !== null;
   $: showToc = hasToc && $page.url.pathname == post.path;
-  $: adaptedToc = post.toc !== null ? post.toc.replaceAll('href="#', `href="${post.path}/#`) : post.toc;
+
+  $: adaptedToc = showToc && post.toc !== null ? post.toc.replaceAll('href="#', `href="${post.path}/#`) : post.toc;
 
   let collapsed = true;
   $: collapsed_icon  = collapsed ? faPlus : faMinus;
@@ -72,7 +72,7 @@
   }
 
   a, .toc :global(a) {
-    color: inherit !important;
+    color: var(--nav-text-color, inherit) !important;
   }
 
   .nav-text {
@@ -86,6 +86,7 @@
   }
 
   .toc-collapse {
+    color: var(--nav-text-color, inherit);
     background: transparent;
     padding-left: 16px;
     padding-right: 16px;

--- a/src/components/navItem.svelte
+++ b/src/components/navItem.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import Fa from "svelte-fa";
+	import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
+	import { page } from "$app/stores";
+	import { onMount } from "svelte";
+
+	export let post: App.Post;
+
+	let isNew = (date: string) => {
+		if (date === undefined) return false;
+
+		let delayedDate = new Date();
+		delayedDate.setMonth(delayedDate.getMonth() - 1);
+
+		let postDate = new Date();
+		let args = date.split('/').map((el) => Number.parseInt(el, 10));
+		postDate.setDate(args[0]);
+		postDate.setMonth(args[1] - 1);
+		postDate.setFullYear(args[2]);
+
+		if (isNaN(postDate.getTime())) return false;
+
+		/**
+		 * If the post date is greater than today's date - 1 month, show the span
+		 */
+		return postDate.getTime() > delayedDate.getTime();
+	};
+
+  $: hasToc = post.toc !== null;
+  $: showToc = hasToc && $page.url.pathname == post.path;
+  $: adaptedToc = post.toc !== null ? post.toc.replaceAll('href="#', `href="${post.path}/#`) : post.toc;
+
+  let collapsed = true;
+  $: collapsed_icon  = collapsed ? faPlus : faMinus;
+  $: collapsed_style = collapsed ? "" : `max-height: none`;
+
+  $: {
+    collapsed = $page.url.pathname != post.path
+  }
+</script>
+
+<div class="nav-link">
+  <span class="nav-text">
+    <a class="nav-text-content" href={post.path}>
+      {post.meta.title}
+      {#if isNew(post.meta.date)}<span class="new-badge keepTag" style="margin-right: 5px;">NEW</span
+        >{/if}
+      {#if 'deprecated' in post.meta && post.meta.deprecated}<span class="deprecated-badge"
+          >DEPRECATED</span
+        >{/if}
+      {#if 'archived' in post.meta && post.meta.archived}<span class="archived-badge">ARCHIVED</span
+        >{/if}
+    </a>
+  </span>
+  {#if showToc}
+    <button class="toc-collapse" on:click|stopPropagation={() => collapsed = !collapsed} on:keydown={() => {}}>
+      <span class="icon-right"><Fa icon={collapsed_icon} />
+    </button>
+  {/if}
+</div>
+{#if showToc}
+	<div class="toc" style={collapsed_style}>
+		{ @html adaptedToc }
+	</div>
+{/if}
+
+<style lang="scss">
+  .nav-link {
+    display: flex;
+    align-items: center;
+    padding-right: 0 !important;
+  }
+
+  a, .toc :global(a) {
+    color: inherit !important;
+  }
+
+  .nav-text {
+    flex-grow: 1;
+    line-height: 1;
+    min-height: 36px;
+    display: flex;
+    align-items: center;
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+
+  .toc-collapse {
+    background: transparent;
+    padding-left: 16px;
+    padding-right: 16px;
+    width: 46px;
+    z-index: 5;
+  }
+
+	.toc {
+		text-align: left;
+		font-size: 0.75em;
+		padding-right: 0;
+    max-height: 0;
+    overflow: hidden;
+
+    & :global(> *) {
+        padding-top: 0.4em !important;
+        padding-bottom: 0.4em !important;
+      }
+
+		:global {
+			ul,
+			ol {
+				margin-top: 0;
+				margin-bottom: 0;
+				padding: 0 0 0 1em;
+			}
+
+			li {
+				line-height: 1.3;
+        padding-right: 16px;
+
+				a {
+					display: block;
+				}
+			}
+		}
+	}
+</style>

--- a/src/components/themeButton.svelte
+++ b/src/components/themeButton.svelte
@@ -1,19 +1,21 @@
 <script lang="ts">
     import Fa from "svelte-fa/src/fa.svelte";
     import { faSun, faCircleHalfStroke, faMoon } from "@fortawesome/free-solid-svg-icons";
-	import { theme_index, theme, theme_html } from "../lib/stores";
+	import { theme_index, theme, theme_html, THEME_VALUES } from "../lib/stores";
 	import { derived } from "svelte/store";
 
     export let navLink: Boolean = false;
     export let text: Boolean = false;
     export let inline: Boolean = false;
     $: navTheme = navLink ? 'nav-link' : '';
+    $: height = navLink ? '36px' : 'auto';
 
     const iconTheme = derived(theme, v => {
         if(v === 'auto') return faCircleHalfStroke
         else if(v === 'dark') return faMoon
         else return faSun
     })
+    const all_html = THEME_VALUES.map(t => t.html)
 </script>
 
 {#if text}
@@ -21,14 +23,17 @@
     { $theme_html }
 </span>
 {:else}
-<button id="DarkMode" class:inline={inline} class:float={!inline} on:click="{ theme_index.next }" style="height: 36px;" class="{navTheme} {$theme}">
-    <span>
-        { $theme_html }
+<button id="DarkMode" class:inline={inline} class:float={!inline} on:click="{ theme_index.next }" style="height: {height}" class="{navTheme} {$theme}">
+    <span class="mode-text">
+        {#each all_html as wide_html}
+            <span class="wide-html">{wide_html}</span>
+        {/each}
+        <span>{ $theme_html }</span>
     </span><span id="icon"><Fa icon={$iconTheme} /></span>
 </button>
 {/if}
 
-<style>
+<style lang="scss">
     #DarkMode {
         color: inherit;
     }
@@ -40,9 +45,27 @@
         background: transparent;
     }
     #DarkMode #icon {
-        margin-left: 10px;
+        margin-left: 4px;
+        width: 19px;
+        height: 19px;
+        text-align: center;
     }
-    #DarkMode.float #icon {
-        float: right;
+    .inline .mode-text {
+        margin-bottom: 1px;
+
+        /* trick to get constant width trough text */
+        text-align: left;
+        & > span {
+            display: block;
+        }
+        & .wide-html {
+            height: 0px;
+            max-height: 0px;
+            overflow: hidden;
+        }
+    }
+    #DarkMode > * {
+        display: inline-block;
+        vertical-align: middle;
     }
 </style>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -140,7 +140,7 @@ nav {
 		background-color: var(--shadow-black-30-color)
 	}
 }
-div.content > a.nav-link {
+div.content > .nav-link, nav div.content > * {
 	padding: 0 34px 0;
 
 }
@@ -271,35 +271,6 @@ button {
 
     #nav-bg, #nav-bg.nav-open {
         display: none;
-    }
-}
-
-$toc_width: 370px;
-
-@media (min-width: 1600px) {
-    body.toc main {
-        display: flex;
-    }
-
-    body.toc > header {
-        & + main, & + main + footer {
-            padding-right: calc($toc_width + 20px);
-        }
-    }
-
-    body.toc main {
-        .table-of-content {
-            position: fixed;
-
-            border-left: 1px solid var(--line-color);
-
-            top: 56px;
-            margin: 10px;
-            bottom: 0;
-            height: auto;
-            width: $toc_width;
-            right: 10px;
-        }
     }
 }
 

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -60,9 +60,6 @@ header {
 	background: rgba(0, 0, 0, 0) url(/images/menu.svg) no-repeat;
 	background-size: 100% 100%;
 }
-.header-shadow {
-	box-shadow: 0 0 8px var(--shadow-black-50-color);
-}
 #DarkMode.nav-link {
     text-transform: uppercase;
     &:hover {
@@ -97,15 +94,13 @@ $main-padding: 16px;
 }
 
 $menu_width: 350px;
-
 nav {
 	position: fixed;
 	top: 0;
 	bottom: 0;
 	left: -$menu_width;
 	width: $menu_width;
-	background: var(--background-white-color);
-	box-shadow: 0 0 8px var(--shadow-black-50-color);
+	background: var(--nav-panel-color);
 	overflow: hidden auto;
 	transition: .5s;
 	z-index: 100;
@@ -116,13 +111,14 @@ nav {
 }
 
 #nav-img {
-	height: calc(630px / 3.5);
-	margin: 0 0 16px 0;
-	font-size: 0;
-	background-image: url(/images/nav_image_logo.png);
-	background-repeat: no-repeat, repeat;
-	background-position: center, center;
-	background-size: 100% 100%, contain;
+	padding-left: 10px;
+	text-align: left;
+	display: flex;
+	justify-content: space-between;
+
+	&:global( > button) {
+		flex-grow: 1;
+	}
 }
 .nav-link {
 	display: block;
@@ -133,7 +129,7 @@ nav {
 	line-height: 36px;
 	text-decoration: none;
 	text-align: left;
-	color: var(--text-color) !important;
+	color: var(--nav-text-color, inherit);
 	background-color: var(--nav-background-color);
 
 	&:hover {
@@ -311,7 +307,7 @@ blockquote {
 	line-height: 36px;
 	padding: 0 16px 0;
 	background-color: #0000 !important;
-	color: var(--text-color);
+	color: var(--nav-text-color, inherit);
 
 	&:hover {
 		background-color: var(--shadow-black-30-color) !important;
@@ -325,7 +321,7 @@ blockquote {
 .collapsible:after, .home:after, #DarkMode.nav-link:after {
 	font-size: 13px;
 	margin-left: 5px;
-	color: var(--text-color);
+	color: var(--nav-text-color, inherit);
 	float: right;
 }
 
@@ -534,8 +530,21 @@ footer {
 	text-align: center;
 
 	& > p {
-		margin: 16px 0;
+		margin: 8px 0;
+
+		&:first-child {
+			margin-top: 16px;
+		}
+
+		#DarkMode {
+			margin-bottom: -8px;
+		}
+
+		&:last-child {
+			margin-bottom: 16px;
+		}
 	}
+
 }
 
 :where(h1, h2, h3, h4, h5, h6) {
@@ -544,8 +553,7 @@ footer {
 
 		&::before {
 			content: '#';
-			position: absolute;
-			left: -1.2ch;
+			margin-left: 0.5ch;
 			opacity: 0;
 			text-decoration: underline;
 		}

--- a/src/css/dark.scss
+++ b/src/css/dark.scss
@@ -3,18 +3,20 @@
 	--text-color: #c9d1d9;
 	--secondary-text-color: #c9d1d9;
 
-	--nav-background-color: #161B22;
-	--background-white-color: #161B22;
+	--background-white-color: #313338;
+
+
+	--nav-background-color: #2B2D31;
+	--nav-panel-color: var(--nav-background-color);
+	--nav-text-color: var(--text-color);
+
+	--header-border-color: rgba(0,0,0,0.3);
 
 	--code-quote-text-background-color: rgba(255,255,255,.1);
 
 	--scrollbar-track-color: #0E0E0E;
 	--scrollbar-thumb-color: #3E3E3E;
 	--scrollbar-thumb-hover-color: #575757;
-}
-
-#nav-img {
-  background-image: url(/images/nav_image_logo.png), url(/images/bg_dark.png);
 }
 
 header h1 {

--- a/src/css/light.scss
+++ b/src/css/light.scss
@@ -3,16 +3,18 @@
 	--text-color: #212529;
 	--secondary-text-color: #212529;
 
-	--nav-background-color: #EEE;
 	--background-white-color: #fff;
+
+
+	--nav-background-color: #EEE;
+	--nav-panel-color: #2B2D31;
+	--nav-text-color: #c9d1d9;
+
+	--header-border-color: rgba(0,0,0,0.25);
 
 	--code-quote-text-background-color: rgba(255,255,255,.1);
 
 	--scrollbar-track-color: #F1F1F1;
 	--scrollbar-thumb-color: #C1C1C1;
 	--scrollbar-thumb-hover-color: #A8A8A8;
-}
-
-#nav-img {
-  background-image: url(/images/nav_image_logo.png), url(/images/bg_light.png);
 }

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -44,3 +44,22 @@ $texts: 'p, ul, ol, li, td';
 @mixin menu-transition($elements: all) {
 	transition: $elements .5s;
 }
+
+@mixin little-border($color: rgba(0,0,0,0.3)) {
+	&::after {
+		content: "";
+		display: block;
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		background-color: $color;
+		transition: all .5s;
+		height: 2px;
+	}
+}
+@mixin little-border-color($color: rgba(0,0,0,0.3)) {
+	&::after {
+		background-color: $color;
+	}
+}

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -78,18 +78,3 @@ export const menu_opened = createStore('menu_opened', false, v => v === 'true', 
         set
     }
 })
-
-const TOC_CLASS = "toc"
-const create_toc_store = () => {
-  const { subscribe, set } = writable(false)
-
-  return {
-    subscribe,
-    update: (target: Element | undefined, url: URL) => {
-      console.log("target", target)
-      set(target !== undefined && url.pathname !== '/')
-    },
-    class: TOC_CLASS
-  }
-}
-export const toc = create_toc_store();

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -5,7 +5,7 @@ const THEME_DEFAULT = '0'
 let THEME_INITIAL = Number.parseInt(browser ? window.localStorage.getItem('theme') ?? THEME_DEFAULT : THEME_DEFAULT, 10);
 // hotfix for the old site's theme breaking the new site completely
 if (isNaN(THEME_INITIAL) ) THEME_INITIAL = THEME_DEFAULT as unknown as number
-const THEME_VALUES = [
+export const THEME_VALUES = [
   {
     value: 'auto',
     html: 'Theme: auto'

--- a/src/routes/__error.svelte
+++ b/src/routes/__error.svelte
@@ -58,6 +58,10 @@
 		<style lang="scss">
 			@use "../css/dark.scss";
 		</style>
+	{:else if $theme === 'light' || ($theme === 'auto' && browser && window.matchMedia('(prefers-color-scheme: light)').matches)}
+		<style lang="scss">
+			@use '../css/light.scss';
+		</style>
 	{/if}
 </svelte:head>
 
@@ -76,12 +80,16 @@
     </main>
 {/key}
 
-<Footer />
+<Footer absolute />
 
 <style lang="scss">
     h1, p {
         color: #ccc;
     }
+
+	:global(body) {
+		position: relative;
+	}
 
 	main #content {
 		padding-top: 56px;

--- a/src/routes/api/posts.json.ts
+++ b/src/routes/api/posts.json.ts
@@ -1,13 +1,54 @@
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+import { JSDOM } from 'jsdom';
+
+const __dirname = dirname(fileURLToPath(new URL(import.meta.url)));
+
+interface FileInfo {
+  metadata: Record<string, object>
+}
+
+function extractTableOfContents(filePath: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    fs.readFile(filePath, 'utf8', (err, data) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      const dom = new JSDOM(data);
+      const document = dom.window.document;
+      const tableOfContentsDivs = document.getElementsByClassName('table-of-content');
+
+      if (tableOfContentsDivs.length > 0) {
+        const tableOfContentsDiv = tableOfContentsDivs[0];
+        const headerTag = tableOfContentsDiv.querySelector('h1, h2, h3, h4, h5, h6');
+
+        if (headerTag) {
+          headerTag.remove();
+        }
+
+        resolve(tableOfContentsDiv.innerHTML.trim());
+      } else {
+        reject(new Error('Table of contents not found.'));
+      }
+    });
+  });
+}
+
 export const GET = async () => {
   const postFiles = import.meta.glob('../pages/*/*.md');
   const iterablePostFiles = Object.entries(postFiles);
 
   const posts = await Promise.all(
     iterablePostFiles.map(async ([path, resolver]) => {
-      const { metadata } = await resolver();
+      const resolved = await resolver();
+      const { metadata } = resolved as FileInfo;
       const postPath = path.slice(2, -3);
 
       return {
+        toc: await extractTableOfContents(join(__dirname, path)).catch(() => null),
         meta: metadata,
         path: postPath,
       };

--- a/src/routes/layout.svelte
+++ b/src/routes/layout.svelte
@@ -19,10 +19,8 @@
 	import Header from "../components/header.svelte";
 	import Footer from "../components/footer.svelte";
 	import "../css/app.scss";
-	import { theme, toc } from "../lib/stores";
+	import { theme } from "../lib/stores";
 	import { fade } from "svelte/transition";
-	import { onMount } from "svelte";
-	import { afterNavigate } from "$app/navigation";
 
 	// mdsvex title prop
 	// @ts-ignore
@@ -34,27 +32,6 @@
 	// @ts-ignore
 	$: full_title = `${title} - Faithful Pack Docs`;
 	$: url = $page.url.href;
-
-	onMount(() => {
-		// clean way to toggle class
-		const toc_unsubscribe = toc.subscribe(value => {
-			document.body.classList[value ? 'add' : 'remove'](toc.class);
-		})
-
-		// callback function to unsubscribe when destroying
-		return toc_unsubscribe;
-	})
-
-	// @ts-ignore
-	let slot;
-	afterNavigate(({ from, to }) => {
-		// triggered twice before and after content refresh
-		if(from?.toString() === to.toString()) return;
-		// @ts-ignore
-		let toc_element = slot?.getElementsByClassName("table-of-content")[0];
-		if(!toc_element) toc_element = undefined;
-		toc.update(toc_element, $page.url);
-	})
 </script>
 
 <svelte:head>
@@ -83,7 +60,7 @@
 
 {#key currentRoute}
 	<main in:fade={{ duration: 150, delay: 150 }} out:fade={{ duration: 150 }}>
-        <div id="container" bind:this={slot}>
+        <div id="container">
             <slot />
         </div>
 	</main>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -63,8 +63,10 @@ const config = {
 			layout: "./src/routes/layout.svelte",
 			rehypePlugins: [
 				rehypeSlug,
-				rehypeAutolinkHeadings
-			]
+				() => rehypeAutolinkHeadings({
+					behavior: "append"
+				})
+			],
 		})
 	]),
 


### PR DESCRIPTION
hello,

This PR is made to solve #20.

I finished the work on the table of content for the table of content inside the navigation, i used the posts json loader in order to extract html element when browsing posts.

I can now have all the table of contents for all the articles. 
I first made the table of content for all articles but realized we have some navigation problems due to the page loading then scrolling, and it wasn't really smooth.

I then changed to only show active article table of content.

Colors, font sizes and icons can still be adjusted. 

All discussion details should be here for centralized discussion.

Screenshots:
![image](https://github.com/Faithful-Resource-Pack/Docs/assets/18086786/4e827ccb-58bf-4ec7-a350-ac28102f3065)
